### PR TITLE
Add loading spinner for initial page load.

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,9 @@
     <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
+    <div class="loaderContainer" id="loaderContainer">
+      <div class="loader"></div>
+    </div>
     <div class="formContainer" id="formContainer">
       <div>
         <h1 class="formHeader">Witness3DWebSimulationViewer</h1>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "witness3dwebsimulationviewer",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "witness3dwebsimulationviewer",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "devDependencies": {
         "@babylonjs/core": "^7.26.4",
         "@babylonjs/gui": "^7.28.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "witness3dwebsimulationviewer",
   "private": true,
-  "version": "0.0.19",
+  "version": "0.0.20",
   "type": "module",
   "scripts": {
     "dev": "vite --port 4000",

--- a/public/styles.css
+++ b/public/styles.css
@@ -7,11 +7,41 @@ body {
   padding: 0;
 }
 
+.loaderContainer {
+  width: 100%;
+  height: 100%;
+  overflow-y: auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+}
+
+.loader {
+  border: 16px solid #f3f3f3;
+  border-radius: 50%;
+  /* Same colour as the default background colour in Babylon.js */
+  border-top: 16px solid #33334c;
+  width: 120px;
+  height: 120px;
+  min-height: 120px;
+  animation: spin 2s linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
 .formContainer {
   overflow-y: auto;
   width: 100%;
   height: 100%;
-  display: flex;
+  display: none;
   justify-content: center;
   align-items: center;
   flex-direction: column;

--- a/src/app.ts
+++ b/src/app.ts
@@ -208,7 +208,8 @@ export class App {
 
     button.onPointerClickObservable.add(() => {
       this.canvas.remove();
-      this.formContainer.style.display = "";
+      // Must set the display to 'flex' because, by default, the display is 'none'
+      this.formContainer.style.display = "flex";
       document.body.style.cursor = "";
     });
 

--- a/src/startup.test.ts
+++ b/src/startup.test.ts
@@ -12,6 +12,8 @@ const fileUploadBtnErrorMessage =
   "Element of id 'fileUploadBtn' was unable to be found within index.html";
 const formContainerErrorMessage =
   "Element of id 'formContainer' was unable to be found within index.html";
+const loaderContainerErrorMessage =
+  "Element of id 'loaderContainer' was unable to be found within index.html";
 
 describe("test startup function", () => {
   beforeEach(async () => {
@@ -76,6 +78,16 @@ describe("test startup function", () => {
     // Correct exception has been thrown
     expect(() => getFileUploadElements()).toThrowError(
       formContainerErrorMessage,
+    );
+  });
+
+  it(`should throw exception if loaderContainer element cannot be found`, () => {
+    const loaderContainer = document.getElementById("loaderContainer");
+    loaderContainer?.remove();
+
+    // Correct exception has been thrown
+    expect(() => getFileUploadElements()).toThrowError(
+      loaderContainerErrorMessage,
     );
   });
 });

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -1,6 +1,24 @@
 import { FileUpload } from "./fileUpload";
 
 /**
+ * Respond to loading of bundled JavaScript in the browser: hide initial loader element
+ * and show the loaderContainer, allowing the user to interact with the form to submit w3d file
+ * @param formContainer Element of id 'formContainer' in HTML document
+ */
+function hideSpinner(formContainer: HTMLElement): void {
+  const loaderContainer = document.getElementById("loaderContainer");
+
+  if (!loaderContainer) {
+    throw new Error(
+      "Element of id 'loaderContainer' was unable to be found within index.html",
+    );
+  }
+
+  loaderContainer.style.display = "none";
+  formContainer.style.display = "flex";
+}
+
+/**
  * Ascertain the correct HTML elements TypeScript code needs to handle the input form,
  * whereby user upload a w3d file, from the index.html file.
  * @returns Object of the HTML elements TypeScript logic requires to handle input form
@@ -19,6 +37,10 @@ export function getFileUploadElements(): {
       "Element of id 'formContainer' was unable to be found within index.html",
     );
   }
+
+  // We know that 'formContainer' exists, so we can safely hide the spinner
+  // and show the form instead
+  hideSpinner(formContainer);
 
   const w3dFileInput = document.getElementById("w3dFile");
 


### PR DESCRIPTION
- Related to this [user story](https://dev.azure.com/lukefcourtney/Witness3DWebSimulationViewer/_workitems/edit/17). Users will see a spinner on the screen until the JavaScript bundle, representing the web application and containing the Babylon.js code necessary, is loaded in the browser.