### PR TITLE
Refactor SimulationTagData interface so that it resides within interf…

### DIFF
--- a/src/interfaces/simulationTagData.ts
+++ b/src/interfaces/simulationTagData.ts
@@ -1,0 +1,13 @@
+import { Scene } from "@babylonjs/core";
+import { MeshGeometry } from "../meshGeometry/meshGeometry";
+import { SimulationTag } from "../simulationTags/simulationTag";
+
+/**
+ * Interface specifically for formatting the data that every concrete class implementation of 'SimulationTagData' will have.
+ * To be precise, it contains the data from the wider Babylon.js scene that the class might need for performing its operations.
+ */
+export interface SimulationTagData {
+  scene: Scene;
+  geometriesMap: Map<string, MeshGeometry>;
+  timeTagStore: Map<string, SimulationTag[]>;
+}

--- a/src/simulationContent/simulationContentFormat.test.ts
+++ b/src/simulationContent/simulationContentFormat.test.ts
@@ -50,11 +50,10 @@ function mockSimulationTag() {
   };
 }
 
-// mock SimulationTagData class
+// mock SimulationTag class
 vi.mock(import("../simulationTags/simulationTag"), () => {
   const SimulationTag = vi.fn();
-  const SimulationTagData = vi.fn();
-  return { SimulationTag, SimulationTagData };
+  return { SimulationTag };
 });
 
 describe("SimulationContentFormat class", () => {

--- a/src/simulationContent/simulationContentFormat.ts
+++ b/src/simulationContent/simulationContentFormat.ts
@@ -1,9 +1,7 @@
 import { CreateTag } from "../interfaces/createTag";
 import { UpdateTag } from "../interfaces/updateTag";
-import {
-  SimulationTag,
-  SimulationTagData,
-} from "../simulationTags/simulationTag";
+import { SimulationTag } from "../simulationTags/simulationTag";
+import { SimulationTagData } from "../interfaces/simulationTagData";
 import { SimulationCreateTag } from "../simulationTags/simulationCreateTag";
 import { SimulationUpdateTag } from "../simulationTags/simulationUpdateTag";
 import { DeleteTag } from "../interfaces/deleteTag";

--- a/src/simulationTags/SimulationDeleteTag.ts
+++ b/src/simulationTags/SimulationDeleteTag.ts
@@ -1,4 +1,5 @@
-import { SimulationTag, SimulationTagData } from "./simulationTag";
+import { SimulationTag } from "./simulationTag";
+import { SimulationTagData } from "../interfaces/simulationTagData";
 import { DeleteTag } from "../interfaces/deleteTag";
 
 /**

--- a/src/simulationTags/simulationCreateTag.ts
+++ b/src/simulationTags/simulationCreateTag.ts
@@ -5,7 +5,8 @@ import {
   Vector3,
 } from "@babylonjs/core";
 import { MeshGeometry } from "../meshGeometry/meshGeometry";
-import { SimulationTag, SimulationTagData } from "./simulationTag";
+import { SimulationTag } from "./simulationTag";
+import { SimulationTagData } from "../interfaces/simulationTagData";
 import { CreateTag } from "../interfaces/createTag";
 import { MachineGeometry } from "../meshGeometry/machineGeometry";
 import { ConveyorBuilder } from "../meshBuilder/conveyorBuilder";

--- a/src/simulationTags/simulationTag.ts
+++ b/src/simulationTags/simulationTag.ts
@@ -1,15 +1,4 @@
-import { Scene } from "@babylonjs/core";
-import { MeshGeometry } from "../meshGeometry/meshGeometry";
-
-/**
- * Interface specifically for formatting the data that every concrete class implementation of 'SimulationTagData' will have.
- * To be precise, it contains the data from the wider Babylon.js scene that the class might need for performing its operations.
- */
-export interface SimulationTagData {
-  scene: Scene;
-  geometriesMap: Map<string, MeshGeometry>;
-  timeTagStore: Map<string, SimulationTag[]>;
-}
+import { SimulationTagData } from "../interfaces/simulationTagData";
 
 /**
  * Abstract class responsible for describing the format through which the functionality of a specific tag type will be invoked.

--- a/src/simulationTags/simulationUpdateTag.ts
+++ b/src/simulationTags/simulationUpdateTag.ts
@@ -1,5 +1,6 @@
 import { Vector3, Tools } from "@babylonjs/core";
-import { SimulationTag, SimulationTagData } from "./simulationTag";
+import { SimulationTag } from "./simulationTag";
+import { SimulationTagData } from "../interfaces/simulationTagData";
 import { UpdateTag } from "../interfaces/updateTag";
 import { MachineGeometry } from "../meshGeometry/machineGeometry";
 import { ConveyorGeometry } from "../meshGeometry/conveyorGeometry";


### PR DESCRIPTION
…aces folder

- Creating the UML package diagram was what prompted this change. Based on making this diagram, I realised that it made more sense to move this interface to the interfaces folder.